### PR TITLE
Fix user dropdown when screen's width is smaller than 1260px

### DIFF
--- a/style.css
+++ b/style.css
@@ -162,4 +162,33 @@
   padding-right:10px!important;
 }  
 
+  @media only screen and (max-width:1259px) {
+
+    body:not(.scrobbles-layout) .main-content {
+      margin-top:60px;
+    }
+
+    body:not(.scrobbles-layout) .dropdown {
+      margin:-55px -30px 0px 0px;
+    }
+
+    .header-title {
+      margin-top:15px!important;
+      margin-left:0!important;
+    }
+
+    .header-title-secondary {
+      margin-left:0!important;
+    }
+
+    .header-featured-track {
+      margin-right:0;
+    }
+
+    .header-metadata-global-stats {
+      margin-left:0!important;
+    }
+
+  }
+
 }


### PR DESCRIPTION
This places the user dropdown menu above the navigation bar
if the screen's width is smaller than 1260 pixels.
